### PR TITLE
Add create & update endpoints to requisitions

### DIFF
--- a/source/includes/requisitions/_create.md.erb
+++ b/source/includes/requisitions/_create.md.erb
@@ -1,0 +1,66 @@
+## Create Requisition
+
+```http
+POST https://api.teamtailor.com/v1/requisitions HTTP/1.1
+Authorization: Token token=abc123abc123
+X-Api-Version: <%= config[:api_version] %>
+
+{
+  "data": {
+    "type": "requisitions",
+    "attributes": {
+      "country": "Sweden",
+      "job-title": "Created by API",
+      "status": "approved"
+    },
+    "relationships": {
+      "location": {
+        "data": {
+          "id": 1,
+          "type": "locations"
+        }
+      }
+    }
+  }
+}
+```
+
+```shell
+curl -X "POST" "https://api.teamtailor.com/v1/requisitions" \
+     -H "Authorization: Token token=abc123abc123" \
+     -H "X-Api-Version: <%= config[:api_version] %>"
+     -H "Content-Type: application/vnd.api+json" \
+     -d "{\"data\":{\"type\":\"requisitions\",\"attributes\":{\"country\":\"Sweden\",\"job-title\":\"Created by API\",\"status\":\"approved\"},\"relationships\":{\"location\":{\"data\":{\"id\":1,\"type\":\"locations\"}}}}}"
+```
+
+
+
+> Example response
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "requisitions",
+    "links": {
+      "self": "https://api.teamtailor.com/v1/requisitions/1"
+    },
+    "attributes": {
+      "job-title": "Created by API",
+      "job-description": null,
+      "country": "Sweden",
+      "min-salary": null,
+      "max-salary": null,
+      "currency": "SEK",
+      "salary-time-unit": "monthly",
+      "number-of-openings": null,
+      "custom-form-answers": null,
+      "status": "approved",
+      "hired-count": 0,
+      "created-at": "2020-10-06T17:34:49.740+02:00"
+    }
+  }
+}
+```
+
+Use this endpoint to create a new requisition.

--- a/source/includes/requisitions/_index.md.erb
+++ b/source/includes/requisitions/_index.md.erb
@@ -22,7 +22,9 @@
       "division": "Europe",
       "comments": "We should make sure that the applicant is familiar with the Go programming language"
     },
-    "status": "pending"
+    "status": "pending",
+    "hired_count": 1,
+    "created_at": "2017-01-18T21:20:16.646+01:00"
   },
   "relationships": {
     "location": {
@@ -73,6 +75,8 @@ salary-time-unit    | string  | "monthly" / "yearly" / "hourly"
 number-of-openings  | integer | The number of people expected to be hired
 custom-form-answers | JSON    | A list of key-value pairs. This will only have a value if the company has actively created a custom form in their requisition settings
 status              | string  | "pending" / "rejected" / "approved" / "archived" / "completed"
+hired_count         | integer | The number of hires from jobs related to the requisition
+created_at          | date    |
 
 
 ### Relations

--- a/source/includes/requisitions/_index.md.erb
+++ b/source/includes/requisitions/_index.md.erb
@@ -22,7 +22,7 @@
       "division": "Europe",
       "comments": "We should make sure that the applicant is familiar with the Go programming language"
     },
-    "requisition-status": "pending"
+    "status": "pending"
   },
   "relationships": {
     "location": {
@@ -72,7 +72,7 @@ currency            | string  | The currency that the salary is set in
 salary-time-unit    | string  | "monthly" / "yearly" / "hourly"
 number-of-openings  | integer | The number of people expected to be hired
 custom-form-answers | JSON    | A list of key-value pairs. This will only have a value if the company has actively created a custom form in their requisition settings
-requisition-status  | string  | "pending" / "rejected" / "approved" / "archived" / "completed"
+status              | string  | "pending" / "rejected" / "approved" / "archived" / "completed"
 
 
 ### Relations

--- a/source/includes/requisitions/_update.md.erb
+++ b/source/includes/requisitions/_update.md.erb
@@ -1,0 +1,55 @@
+## Update Note
+
+```http
+PUT https://api.teamtailor.com/v1/requisitions/1 HTTP/1.1
+Authorization: Token token=abc123abc123
+X-Api-Version: <%= config[:api_version] %>
+
+{
+  "data": {
+    "type": "requisitions",
+    "attributes": {
+      "job-title": "Updated by API",
+      "status": "pending"
+    }
+  }
+}
+```
+
+```shell
+curl -X "PATCH" "https://api.teamtailor.com/v1/requisitions/1" \
+     -H "Authorization: Token token=abc123abc123" \
+     -H "X-Api-Version: <%= config[:api_version] %>"
+     -H "Content-Type: application/vnd.api+json" \
+     -d "{\"data\":{\"id\":\"8\",\"type\":\"requisitions\",\"attributes\":{\"job-title\":\"Updated by API\",\"status\":\"pending\"}}}"
+```
+
+> Example response
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "requisitions",
+    "links": {
+      "self": "https://api.teamtailor.com/v1/requisitions/1"
+    },
+    "attributes": {
+      "job-title": "Updated by API",
+      "job-description": null,
+      "country": "Sweden",
+      "min-salary": null,
+      "max-salary": null,
+      "currency": "SEK",
+      "salary-time-unit": "monthly",
+      "number-of-openings": null,
+      "custom-form-answers": null,
+      "status": "pending",
+      "hired-count": 0,
+      "created-at": "2020-10-06T17:34:49.740+02:00"
+    }
+  }
+}
+```
+
+Use this endpoint to update the attributes or the status of a requisition.

--- a/source/includes/requisitions/_update.md.erb
+++ b/source/includes/requisitions/_update.md.erb
@@ -1,4 +1,4 @@
-## Update Note
+## Update Requisition
 
 ```http
 PUT https://api.teamtailor.com/v1/requisitions/1 HTTP/1.1


### PR DESCRIPTION
They were missing from the documentation.

This also adds the missing parametres `status`, `hired_count` and `created_at`.